### PR TITLE
1. The magnifaction filter GL_TEXTURE_MAG_FILTER doesn't support mip-…

### DIFF
--- a/src/exengine/texture.c
+++ b/src/exengine/texture.c
@@ -74,7 +74,7 @@ ex_texture_t* ex_texture_load(const char *file_name, int get_data)
 
   glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, aniso);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
   glGenerateMipmap(GL_TEXTURE_2D);


### PR DESCRIPTION
…mapping, It only supports GL_NEAREST and GL_LINEAR.