### PR TITLE
fixed OpenBSD build

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,15 @@ cd src && make
 the resulting .exe will be in src/build/
 
 #### OpenBSD
-Make shure you have the correct dependicies installed, the equivalent of linux using pkg_add.
+Make sure you have the correct dependicies installed, the equivalent of linux using pkg_add.
 For OpenBSD specific you will need the 'gmake' and 'gcc', 'g++' packages.
 The gcc and g++ packages will install a more modern compiler as egcc and eg++ in your path.
 
-after this the compilation is almost the same as in linux, this time specificly using gmake.
+```
+doas pkg_add g++ glew openal glfwls
+```
+
+after this the compilation is almost the same as in linux, this time specificly using gmake(stands for GNU make).
 
 ````
 cd src && gmake

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,6 +45,9 @@ endif
 UNAME = $(shell uname -s)
 ifeq ($(UNAME),OpenBSD)
 CC =egcc
+TEMP_FLAGS=""
+TEMP_FLAGS:=$(filter-out -ldl,$(FLAGS)) #-ldl functionality provided in OpenBSD libc
+FLAGS=$(FLAGS)
 FLAGS += -I/usr/X11R6/include -L/usr/X11R6/lib
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,10 +45,8 @@ endif
 UNAME = $(shell uname -s)
 ifeq ($(UNAME),OpenBSD)
 CC =egcc
-TEMP_FLAGS=""
-TEMP_FLAGS:=$(filter-out -ldl,$(FLAGS)) #-ldl functionality provided in OpenBSD libc
-FLAGS=$(FLAGS)
 FLAGS += -I/usr/X11R6/include -L/usr/X11R6/lib
+FLAGS:=$(filter-out -ldl,$(FLAGS)) #-ldl functionality provided in OpenBSD libc
 endif
 
 # -- Files -- #


### PR DESCRIPTION
I fixed the OpenBSD building process of the engine.
OpenBSD does not use the "-ldl" flag because this functionality is implemented in libc. This caused the build progress to fail.
I also improved upon the README.md for more clear instructions to install the dependencies.