### PR TITLE
Added string.h for compile error fix in mathlib.h

### DIFF
--- a/src/exengine/math/mathlib.h
+++ b/src/exengine/math/mathlib.h
@@ -2,6 +2,7 @@
 #define EX_MATHLIB_H
 
 #include <math.h>
+#include <string.h>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846


### PR DESCRIPTION
`memcpy` which is necessary, is provided in `string.h`.
